### PR TITLE
fix: preserve PDS-side fields (e.g. bskyPostRef) on document update

### DIFF
--- a/packages/cli/src/lib/atproto.ts
+++ b/packages/cli/src/lib/atproto.ts
@@ -322,7 +322,16 @@ export async function updateDocument(
 		textContent = stripMarkdownForText(post.content);
 	}
 
+	// Fetch existing record to preserve PDS-side fields (e.g. bskyPostRef)
+	const existingResponse = await agent.com.atproto.repo.getRecord({
+		repo: agent.did!,
+		collection: collection!,
+		rkey: rkey!,
+	});
+	const existingRecord = existingResponse.data.value as Record<string, unknown>;
+
 	const record: Record<string, unknown> = {
+		...existingRecord,
 		$type: "site.standard.document",
 		title: post.frontmatter.title,
 		site: config.publicationUri,


### PR DESCRIPTION
## Summary

- Fetches the existing record from the PDS before updating a document
- Spreads existing record fields into the new record so PDS-side fields like `bskyPostRef` are not lost on update

## Test plan

- [ ] Update a document that has already been synced to Bluesky and confirm `bskyPostRef` is preserved after the update
- [ ] Verify other document fields are still correctly updated